### PR TITLE
Set homepage background image without blur

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,10 +11,10 @@ body {
 .bg {
   position: fixed;
   inset: 0;
-  background-image: url('https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?q=80&w=1600&auto=format&fit=crop');
+  background-image: url('/assets/home-bg.jpg');
   background-size: cover;
   background-position: center;
-  filter: brightness(0.55) saturate(1.1);
+  filter: none;
   z-index: -1;
 }
 
@@ -77,7 +77,7 @@ body {
   border-radius: 14px;
   padding: 16px;
   color: #F3F4F6;
-  backdrop-filter: blur(6px);
+  backdrop-filter: none;
 }
 .section + .section { margin-top: 16px; }
 .section h2 { margin: 6px 0 12px; font-size: 20px; }


### PR DESCRIPTION
Set homepage background image to `/assets/home-bg.jpg` and remove all blur effects.

---
<a href="https://cursor.com/background-agent?bcId=bc-d053c492-4149-42ff-915d-2ae67e6bed2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d053c492-4149-42ff-915d-2ae67e6bed2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

